### PR TITLE
Add some extra methods and one more attribute.

### DIFF
--- a/pymitv/control.py
+++ b/pymitv/control.py
@@ -43,6 +43,17 @@ class Control:
         return True
 
     @staticmethod
+    def change_source(ip, source):
+        """Select source hdmi1 or hdmi2"""
+        tv_url = 'http://{}:6095/controller?action=changesource&source='.format(ip)
+        source = source
+        request = requests.get(tv_url + source)
+        if request.status_code != 200:
+            return False
+
+        return True
+
+    @staticmethod
     def mute(ip):
         """Polyfill for muting the TV."""
         tv_url = 'http://{}:6095/controller?action=keyevent&keycode='.format(ip)

--- a/pymitv/control.py
+++ b/pymitv/control.py
@@ -27,9 +27,9 @@ class Control:
         print()
 
     @staticmethod
-    def send_keystrokes(ip, keystrokes, wait=False):
+    def send_keystrokes(ip_address, keystrokes, wait=False):
         """Connects to TV and sends keystroke via HTTP."""
-        tv_url = 'http://{}:6095/controller?action=keyevent&keycode='.format(ip)
+        tv_url = 'http://{}:6095/controller?action=keyevent&keycode='.format(ip_address)
 
         for keystroke in keystrokes:
             if keystroke == 'wait' or wait is True:
@@ -44,9 +44,9 @@ class Control:
         return True
 
     @staticmethod
-    def change_source(ip, source):
+    def change_source(ip_address, source):
         """Select source hdmi1 or hdmi2"""
-        tv_url = 'http://{}:6095/controller?action=changesource&source='.format(ip)
+        tv_url = 'http://{}:6095/controller?action=changesource&source='.format(ip_address)
         source = source
         request = requests.get(tv_url + source)
         if request.status_code != 200:
@@ -55,9 +55,9 @@ class Control:
         return True
 
     @staticmethod
-    def mute(ip):
+    def mute(ip_address):
         """Polyfill for muting the TV."""
-        tv_url = 'http://{}:6095/controller?action=keyevent&keycode='.format(ip)
+        tv_url = 'http://{}:6095/controller?action=keyevent&keycode='.format(ip_address)
 
         count = 0
         while count > 30:
@@ -70,12 +70,12 @@ class Control:
         return True
 
     @staticmethod
-    def check_state(ip):
+    def check_state(ip_address):
         """Check if xiaomi tv is reachable"""
         request_timeout = 0.1
 
         try:
-            tv_url = 'http://{}:6095/request?action=isalive'.format(ip)
+            tv_url = 'http://{}:6095/request?action=isalive'.format(ip_address)
             requests.get(tv_url, timeout=request_timeout)
         except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
             return False
@@ -83,12 +83,12 @@ class Control:
         return True
 
     @staticmethod
-    def get_volume(ip):
+    def get_volume(ip_address):
         """Get the current volume of xiaomi tv"""
         request_timeout = 0.1
 
         try:
-            tv_url = 'http://{}:6095/general?action=getVolum'.format(ip)
+            tv_url = 'http://{}:6095/general?action=getVolum'.format(ip_address)
             request = requests.get(tv_url, timeout=request_timeout)
         except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
             return False

--- a/pymitv/control.py
+++ b/pymitv/control.py
@@ -70,6 +70,19 @@ class Control:
         return True
 
     @staticmethod
+    def check_state(ip):
+        """Check if xiaomi tv is reachable"""
+        request_timeout = 0.1
+
+        try:
+            tv_url = 'http://{}:6095/request?action=isalive'.format(ip)
+            requests.get(tv_url, timeout=request_timeout)
+        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
+            return False
+
+        return True
+
+    @staticmethod
     def get_volume(ip):
         """Get the current volume of xiaomi tv"""
         request_timeout = 0.1

--- a/pymitv/control.py
+++ b/pymitv/control.py
@@ -2,6 +2,7 @@
 The pymitv.Control module is in charge of sending keystrokes to the TV.
 """
 import time
+import json
 import requests
 
 
@@ -67,3 +68,17 @@ class Control:
                 return False
 
         return True
+
+    @staticmethod
+    def get_volume(ip):
+        """Get the current volume of xiaomi tv"""
+        request_timeout = 0.1
+
+        try:
+            tv_url = 'http://{}:6095/general?action=getVolum'.format(ip)
+            request = requests.get(tv_url, timeout=request_timeout)
+        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
+            return False
+
+        volume = json.loads(request.json()['data'])['volum']
+        return volume

--- a/pymitv/discover.py
+++ b/pymitv/discover.py
@@ -49,7 +49,7 @@ class Discover:
         try:
             tv_url = 'http://{}:6095/request?action=isalive'.format(ip)
             request = requests.get(tv_url, timeout=request_timeout)
-        except requests.exceptions.ConnectTimeout:
+        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
             return False
 
         return request.status_code == 200

--- a/pymitv/discover.py
+++ b/pymitv/discover.py
@@ -19,11 +19,11 @@ class Discover:
             # Find IP address of computer pymitv is running on
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             sock.connect(("8.8.8.8", 80))
-            ip = sock.getsockname()[0]
+            ip_address = sock.getsockname()[0]
             sock.close()
 
             # Get IP and compose a base like 192.168.1.xxx
-            ip_parts = ip.split('.')
+            ip_parts = ip_address.split('.')
             base_ip = ip_parts[0] + '.' + ip_parts[1] + '.' + ip_parts[2]
 
         # Loop through every IP and check if TV is alive
@@ -39,15 +39,15 @@ class Discover:
         return tvs
 
     @staticmethod
-    def check_ip(ip, log=False):
+    def check_ip(ip_address, log=False):
         """Attempts a connection to the TV and checks if there really is a TV."""
         if log:
-            print('Checking ip: {}...'.format(ip))
+            print('Checking ip: {}...'.format(ip_address))
 
         request_timeout = 0.1
 
         try:
-            tv_url = 'http://{}:6095/request?action=isalive'.format(ip)
+            tv_url = 'http://{}:6095/request?action=isalive'.format(ip_address)
             request = requests.get(tv_url, timeout=request_timeout)
         except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
             return False

--- a/pymitv/tv.py
+++ b/pymitv/tv.py
@@ -9,7 +9,7 @@ class TV:
     state = True
     source = None
 
-    def __init__(self, ip=None, source=None, initialized=True):
+    def __init__(self, ip=None, source=None, initialized=True, assume_state=True):
         # Check if an IP address has been supplied to the constructor
         if ip is None:
             print('No TV supplied, hence it won\'t work')
@@ -24,6 +24,9 @@ using any of the polyfill controls, could produce weird results.')
 
         # Make active source global
         self.source = source
+
+        # Set assume_state
+        self.assume_state = assume_state
 
         # Set volume
         self.volume = Control().get_volume(self.ip)
@@ -60,8 +63,10 @@ using any of the polyfill controls, could produce weird results.')
 
     @property
     def is_on(self):
-        """Returns the assumed state of the TV."""
-        return self.state
+        """Returns the assume state of the TV."""
+        if self.assume_state:
+            return self.state
+        return Control().check_state(self.ip)
 
     def wake(self):
         """Wakes up the TV from sleep."""

--- a/pymitv/tv.py
+++ b/pymitv/tv.py
@@ -5,13 +5,13 @@ from pymitv import Navigator
 
 class TV:
     """A virtual representation of the TV that stores state, and takes controls."""
-    ip = None
+    ip_address = None
     state = True
     source = None
 
-    def __init__(self, ip=None, source=None, initialized=True, assume_state=True):
+    def __init__(self, ip_address=None, source=None, initialized=True, assume_state=True):
         # Check if an IP address has been supplied to the constructor
-        if ip is None:
+        if ip_address is None:
             print('No TV supplied, hence it won\'t work')
 
         # Check if TV has been initialized for pymitv control
@@ -20,7 +20,7 @@ class TV:
 using any of the polyfill controls, could produce weird results.')
 
         # Make IP address global regardless of value
-        self.ip = ip
+        self.ip_address = ip_address
 
         # Make active source global
         self.source = source
@@ -29,15 +29,15 @@ using any of the polyfill controls, could produce weird results.')
         self.assume_state = assume_state
 
         # Set volume
-        self.volume = Control().get_volume(self.ip)
+        self.volume = Control().get_volume(self.ip_address)
 
     def _send_keystroke(self, keystroke, wait=False):
         # Check if an IP address has been supplied, if it hasn't return false.
-        if self.ip is None:
+        if self.ip_address is None:
             return False
 
         # Make sure the TV is not already on, and then send keystroke
-        return Control().send_keystrokes(self.ip, keystroke, wait)
+        return Control().send_keystrokes(self.ip_address, keystroke, wait)
 
         # Send True regardless of whether or not command was sent
         #return True
@@ -45,19 +45,19 @@ using any of the polyfill controls, could produce weird results.')
     def change_source(self, source):
         """Change source of xiaomi tv"""
         # Check if an IP address has been supplied, if it hasn't return false.
-        if self.ip is None:
+        if self.ip_address is None:
             return False
 
         self.source = source
-        return Control().change_source(self.ip, source)
+        return Control().change_source(self.ip_address, source)
 
     def get_volume(self):
         """Get volume of xiaomi tv"""
         # Check if an IP address has been supplied, if it hasn't return false.
-        if self.ip is None:
+        if self.ip_address is None:
             return False
 
-        self.volume = Control().get_volume(self.ip)
+        self.volume = Control().get_volume(self.ip_address)
 
         return self.volume
 
@@ -66,7 +66,7 @@ using any of the polyfill controls, could produce weird results.')
         """Returns the assume state of the TV."""
         if self.assume_state:
             return self.state
-        return Control().check_state(self.ip)
+        return Control().check_state(self.ip_address)
 
     def wake(self):
         """Wakes up the TV from sleep."""
@@ -122,7 +122,7 @@ using any of the polyfill controls, could produce weird results.')
 
     def mute(self):
         """Mutes the TV."""
-        return Control().mute(self.ip)
+        return Control().mute(self.ip_address)
 
     def set_source(self, source):
         """Selects and saves source."""

--- a/pymitv/tv.py
+++ b/pymitv/tv.py
@@ -36,6 +36,15 @@ using any of the polyfill controls, could produce weird results.')
         # Send True regardless of whether or not command was sent
         #return True
 
+    def change_source(self, source):
+        """Change source of xiaomi tv"""
+        # Check if an IP address has been supplied, if it hasn't return false.
+        if self.ip is None:
+            return False
+
+        self.source = source
+        return Control().change_source(self.ip, source)
+
     @property
     def is_on(self):
         """Returns the assumed state of the TV."""

--- a/pymitv/tv.py
+++ b/pymitv/tv.py
@@ -25,6 +25,9 @@ using any of the polyfill controls, could produce weird results.')
         # Make active source global
         self.source = source
 
+        # Set volume
+        self.volume = Control().get_volume(self.ip)
+
     def _send_keystroke(self, keystroke, wait=False):
         # Check if an IP address has been supplied, if it hasn't return false.
         if self.ip is None:
@@ -44,6 +47,16 @@ using any of the polyfill controls, could produce weird results.')
 
         self.source = source
         return Control().change_source(self.ip, source)
+
+    def get_volume(self):
+        """Get volume of xiaomi tv"""
+        # Check if an IP address has been supplied, if it hasn't return false.
+        if self.ip is None:
+            return False
+
+        self.volume = Control().get_volume(self.ip)
+
+        return self.volume
 
     @property
     def is_on(self):


### PR DESCRIPTION
Add get_volume method and change_source method.
Change source only supports hdmi1 and hdmi2.
Also add `assume state` attribute because in some cases (for example Xiaomi Projector) switching the device to sleep just turn off the screen but the device keep running normally.
To be able to turn off the projector completely add one more option `assume_state` to handle this case.
An example of the above is [here](https://github.com/ppanagiotis/home-assistant/commit/8d81d7d3dc0209779f5f463273fd519802b5051a)